### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ networks:
 
 services:
   timescaledb:
-    image: timescale/timescaledb:latest
+    image: timescale/timescaledb:latest-pg12
     command: postgres -c shared_preload_libraries=timescaledb
     networks:
       - k6


### PR DESCRIPTION
from https://hub.docker.com/r/timescale/timescaledb
Why is there no latest tag?
In general, it is usually a bad idea to track the latest tag for any Docker image, since you may get unexpectedly upgraded. For TimescaleDB, this is particularly problematic because not only can the version of TimescaleDB change, but also the version of PostgreSQL. If we wanted our latest tag to always be the latest of all dependencies, users could be updated between major versions of PostgreSQL, which requires a pg_upgrade step. That may cause more hassles for the operator than expected.

For these reasons, we do not offer a latest tag, but we do offer a 'latest' equivalent by publishing a latest tag for each PostgreSQL platform we support. For production systems, you should still be explicit about the version you want to use and not these latest tags, but at least you won't have to run a pg_upgrade step unexpectedly.